### PR TITLE
fix: Safari Basic Auth prompts on every API request

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -37,7 +37,9 @@ const API_BASE_URL = "/api";
 export const api = {
   // List all sessions
   async listSessions(): Promise<SessionInfo[]> {
-    const response = await fetch(`${API_BASE_URL}/sessions`);
+    const response = await fetch(`${API_BASE_URL}/sessions`, {
+      credentials: "include",
+    });
     if (!response.ok) {
       throw new Error(`Failed to list sessions: ${response.statusText}`);
     }
@@ -50,6 +52,7 @@ export const api = {
   ): Promise<CreateSessionResponse> {
     const response = await fetch(`${API_BASE_URL}/sessions`, {
       method: "POST",
+      credentials: "include",
       headers: {
         "Content-Type": "application/json",
       },
@@ -68,6 +71,7 @@ export const api = {
   async deleteSession(sessionId: string): Promise<void> {
     const response = await fetch(`${API_BASE_URL}/sessions/${sessionId}`, {
       method: "DELETE",
+      credentials: "include",
     });
 
     if (!response.ok) {
@@ -83,6 +87,7 @@ export const api = {
   ): Promise<void> {
     const response = await fetch(`${API_BASE_URL}/sessions/${sessionId}`, {
       method: "PUT",
+      credentials: "include",
       headers: {
         "Content-Type": "application/json",
       },


### PR DESCRIPTION
## Problem

Safari web browser prompts for username/password on every API request when HTTP Basic Authentication is enabled. Chrome works correctly by reusing cached credentials.

## Root Cause

Safari has stricter credential handling policies. When using  with HTTP Basic Authentication, Safari requires explicit  option to send cached credentials. Without this option, Safari treats each request as unauthenticated.

## Solution

Added  to all fetch requests in the API service:
- `listSessions()`
- `createSession()`
- `deleteSession()`
- `updateSessionName()`

This ensures Safari includes cached Basic Auth credentials in API requests, matching Chrome's behavior.

## Testing

- Frontend builds successfully
- Change is minimal and focused on credential handling